### PR TITLE
Adding virtual light gun support for Menacer and Justifier light guns.

### DIFF
--- a/GEN/GEN.qip
+++ b/GEN/GEN.qip
@@ -11,3 +11,4 @@ set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) g
 set_global_assignment -name VERILOG_FILE [file join $::quartus(qip_path) genesis_lpf.v ]
 set_global_assignment -name VERILOG_FILE [file join $::quartus(qip_path) audio_iir_filter.v ]
 set_global_assignment -name VHDL_FILE [file join $::quartus(qip_path) CART.vhd ]
+set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) lightgun.sv ]

--- a/GEN/gen.sv
+++ b/GEN/gen.sv
@@ -104,6 +104,14 @@ module gen
 	input  [24:0] MOUSE,
 	input   [2:0] MOUSE_OPT,
 	
+	input         GUN_OPT,
+	input         GUN_TYPE,
+	input         GUN_SENSOR,
+	input         GUN_A,
+	input         GUN_B,
+	input         GUN_C,
+	input         GUN_START,
+	
 	output        RAM_CE_N,
 	input         RAM_RDY,
 	
@@ -192,6 +200,7 @@ always @(posedge MCLK) begin
 		if((~old_as & M68K_AS_N) || &scnt) begin
 			if (M68K_VINT) M68K_IPL_N <= 3'b001;
 			else if (M68K_HINT) M68K_IPL_N <= 3'b011;
+			else if (M68K_EXINT) M68K_IPL_N <= 3'b101;
 			else M68K_IPL_N <= 3'b111;
 		end
 	end
@@ -288,6 +297,7 @@ wire        VDP_DTACK_N;
 wire [23:1] VBUS_A;
 wire        VBUS_SEL;
 
+wire        M68K_EXINT;
 wire        M68K_HINT;
 wire        M68K_VINT;
 wire        Z80_VINT;
@@ -368,6 +378,8 @@ wire VDP_hs, VDP_vs;
 assign HS = ~VDP_hs;
 assign VS = ~VDP_vs;
 
+wire HL;
+
 vdp vdp
 (
 	.RST_n(~reset),
@@ -393,6 +405,9 @@ vdp vdp
 	.VRAM32_ack(vram32_ack),
 	.VRAM32_a(vram32_a),
 	.VRAM32_q(vram32_q),
+	
+	.EXINT(M68K_EXINT),
+	.HL(HL),
 	
 	.HINT(M68K_HINT),
 	.VINT_TG68(M68K_VINT),
@@ -535,6 +550,14 @@ multitap multitap
 
 	.MOUSE(MOUSE),
 	.MOUSE_OPT(MOUSE_OPT),
+	
+	.GUN_OPT(GUN_OPT),
+	.GUN_TYPE(GUN_TYPE),
+	.GUN_SENSOR(GUN_SENSOR),
+	.GUN_A(GUN_A),
+	.GUN_B(GUN_B),
+	.GUN_C(GUN_C),
+	.GUN_START(GUN_START),
 
 	.PAL(PAL),
 	.EXPORT(EXPORT),
@@ -544,7 +567,8 @@ multitap multitap
 	.RNW(MBUS_RNW),
 	.DI(MBUS_DO[7:0]),
 	.DO(IO_DO),
-	.DTACK_N(IO_DTACK_N)
+	.DTACK_N(IO_DTACK_N),
+	.HL(HL)
 );
 
 //-----------------------------------------------------------------------

--- a/GEN/lightgun.sv
+++ b/GEN/lightgun.sv
@@ -1,0 +1,158 @@
+
+module lightgun
+(
+	input        CLK,
+	input        RESET,
+
+	input [24:0] MOUSE,
+	input        MOUSE_XY,
+
+	input  [7:0] JOY_X,
+	input  [7:0] JOY_Y,
+	input [11:0] JOY,
+	
+	input        RELOAD,
+
+	input        HDE,VDE,
+	input        CE_PIX,
+	input        H40,
+	
+	input        BTN_MODE,
+	input  [1:0] SIZE,
+	
+	input  [7:0] SENSOR_DELAY,
+	
+	output [2:0] TARGET,
+	output       SENSOR,
+	output       BTN_A,
+	output       BTN_B,
+	output       BTN_C,
+	output       BTN_START
+);
+
+assign TARGET  = { 2'd0, ~offscreen & draw};
+
+reg  [9:0] lg_x, x;
+reg  [8:0] lg_y, y;
+
+wire [10:0] new_x = {lg_x[9],lg_x} + {{3{MOUSE[4]}},MOUSE[15:8]};
+wire [9:0] new_y = {lg_y[8],lg_y} - {{2{MOUSE[5]}},MOUSE[23:16]};
+
+wire [8:0] j_x = {~JOY_X[7], JOY_X[6:0]};
+wire [8:0] j_y = {~JOY_Y[7], JOY_Y[6:0]};
+
+reg offscreen = 0, draw = 0;
+always @(posedge CLK) begin
+	reg old_pix, old_hde, old_vde, old_ms;
+	reg [9:0] hcnt;
+	reg [8:0] vcnt;
+	reg [8:0] vtotal;
+	reg [15:0] hde_d;
+	reg [9:0] xm,xp;
+	reg [8:0] ym,yp;
+	reg [8:0] cross_sz;
+	reg sensor_pend;
+	reg [7:0] sensor_time;
+	reg reload_pressed;
+	reg [2:0] reload_pend;
+	reg [2:0] reload;
+	
+	BTN_A <= reload ? 1'b1 : (reload_pend ? 1'b0 : (BTN_MODE ? MOUSE[0] : (JOY[4]|JOY[9])));
+	if(BTN_MODE ? MOUSE[1] : (JOY[5]|JOY[10])) begin
+		if(RELOAD) begin
+			BTN_B <= 1'b0;
+			reload_pressed <= 1'b1;
+			if(!reload_pressed) begin
+				reload_pend <= 3'd5;
+			end
+		end
+		else BTN_B <= 1'b1;
+	end
+	else begin
+		BTN_B <= 1'b0;
+		reload_pressed <= 1'b0;
+	end
+
+	BTN_C <= (JOY[6]|JOY[11]); // Not mapped to mouse. Unsure if it's used in any game.
+	BTN_START <= BTN_MODE ? MOUSE[2] : (JOY[7]);
+
+	case(SIZE)
+			0: cross_sz <= 8'd1;
+			1: cross_sz <= 8'd3;
+	default: cross_sz <= 8'd0;
+	endcase
+	
+	old_ms <= MOUSE[24];
+	if(MOUSE_XY) begin
+		if(old_ms ^ MOUSE[24]) begin
+			if(new_x[10]) lg_x <= 0;
+			else if(new_x[8] & (new_x[7] | new_x[6])) lg_x <= 320;
+			else lg_x <= new_x[8:0];
+
+			if(new_y[9]) lg_y <= 0;
+			else if(new_y > vtotal) lg_y <= vtotal;
+			else lg_y <= new_y[8:0];
+		end
+	end
+	else begin
+		if(H40) lg_x <= j_x + (j_x >> 2);
+		else lg_x <= j_x;
+
+		if(j_y < 8) lg_y <= 0;
+		else if((j_y - 9'd8) > vtotal) lg_y <= vtotal;
+		else lg_y <= j_y - 9'd8;
+	end
+
+	if(CE_PIX) begin
+		hde_d <= {hde_d[14:0],HDE};
+		old_hde <= hde_d[15];
+		if(~&hcnt) hcnt <= hcnt + 1'd1;
+		if(~old_hde & ~HDE) hcnt <= 0;
+		if(old_hde & ~hde_d[15]) begin
+			if(~VDE) begin
+				vcnt <= 0;
+				if(vcnt) vtotal <= vcnt - 1'd1;
+			end
+			else if(~&vcnt) vcnt <= vcnt + 1'd1;
+		end
+		
+		old_vde <= VDE;
+		if(~old_vde & VDE) begin
+			x  <= lg_x;
+			y  <= lg_y;
+			xm <= lg_x - cross_sz;
+			xp <= lg_x + cross_sz;
+			ym <= lg_y - cross_sz;
+			yp <= lg_y + cross_sz;
+			offscreen <= !lg_y[7:1] || lg_y >= (vtotal-1'd1);
+			
+			if(reload_pend && !reload) begin
+				reload_pend <= reload_pend - 3'd1;
+				if (reload_pend == 3'd1) reload <= 3'd5;
+			end
+			else if (reload) reload <= reload - 3'd1;
+		end
+		
+		if(~&sensor_time) sensor_time <= sensor_time + 1'd1;
+		if(sensor_pend) begin
+			if (sensor_time >= (SENSOR_DELAY)) begin
+				SENSOR <= (!reload_pend && !reload && !offscreen);
+				sensor_pend <= 1'b0;
+				sensor_time <= 8'd0;
+			end
+		end
+		// Keep sensor active for a bit to mimic real light gun behavior.
+		// Required for games that poll instead of using interrupts.
+		else if(sensor_time > 64) SENSOR <= 1'b0;
+	end
+
+	if(HDE && VDE && (x == hcnt) && (y <= vcnt) && (y > vcnt - 8)) begin
+		sensor_pend <= 1'b1;
+		sensor_time <= 8'd0;
+	end
+	
+	draw <= (((SIZE[1] || ($signed(hcnt) >= $signed(xm) && hcnt <= xp)) && y == vcnt) || 
+				((SIZE[1] || ($signed(vcnt) >= $signed(ym) && vcnt <= yp)) && x == hcnt));
+end
+
+endmodule

--- a/GEN/multitap.sv
+++ b/GEN/multitap.sv
@@ -54,6 +54,14 @@ module multitap
 
 	input [24:0] MOUSE,
 	input  [2:0] MOUSE_OPT,
+	
+	input        GUN_OPT,
+	input        GUN_TYPE,
+	input        GUN_SENSOR,
+	input        GUN_A,
+	input        GUN_B,
+	input        GUN_C,
+	input        GUN_START,
 
 	input        PAL,
 	input        EXPORT,
@@ -63,7 +71,8 @@ module multitap
 	input        RNW,
 	input  [7:0] DI,
 	output [7:0] DO,
-	output       DTACK_N
+	output       DTACK_N,
+	output       HL
 );
 
 wire [7:0] GEN_DO;

--- a/GEN/vdp.vhd
+++ b/GEN/vdp.vhd
@@ -73,6 +73,8 @@ entity vdp is
 		vram32_a    : out std_logic_vector(15 downto 1);
 		vram32_q    : in  std_logic_vector(31 downto 0);
 
+		EXINT       : out std_logic;
+		HL          : in  std_logic;
 		HINT        : out std_logic;
 		VINT_TG68   : out std_logic;
 		VINT_T80    : out std_logic;
@@ -196,6 +198,10 @@ signal SCOL_CLR		: std_logic;
 ----------------------------------------------------------------
 -- INTERRUPTS
 ----------------------------------------------------------------
+signal EXINT_PENDING			: std_logic;
+signal EXINT_PENDING_SET		: std_logic;
+signal EXINT_FF					: std_logic;
+
 signal HINT_COUNT	: std_logic_vector(7 downto 0);
 signal HINT_EN		: std_logic;
 signal HINT_PENDING	: std_logic;
@@ -236,9 +242,11 @@ signal WRIGT_LATCH  : std_logic;
 signal BGCOL		: std_logic_vector(5 downto 0);
 
 signal HIT			: std_logic_vector(7 downto 0);
+signal IE2			: std_logic;
 signal IE1			: std_logic;
 signal IE0			: std_logic;
 
+signal OLD_HL 		: std_logic;
 signal M3			: std_logic;
 signal DE			: std_logic;
 signal M5			: std_logic;
@@ -881,6 +889,7 @@ WRIGT <= REG(17)(7);
 BGCOL <= REG(7)(5 downto 0);
 
 HIT <= REG(10);
+IE2 <= REG(11)(3);
 IE1 <= REG(0)(4);
 IE0 <= REG(1)(5);
 
@@ -2300,10 +2309,7 @@ begin
 
 	elsif rising_edge(CLK) then
 
-		if M3='0' then
-			HV <= HV_VCNT_EXT(7 downto 1) & HV8 & HV_HCNT(8 downto 1);
-		end if;
-
+		EXINT_PENDING_SET <= '0';
 		HINT_PENDING_SET <= '0';
 		VINT_TG68_PENDING_SET <= '0';
 		VINT_T80_SET <= '0';
@@ -2318,6 +2324,16 @@ begin
 		--BGA_PATTERN_EN <= '0';
 		BGB_MAPPING_EN <= '0';
 		--BGB_PATTERN_EN <= '0';
+		
+		OLD_HL <= HL;
+		if OLD_HL = '1' and HL = '0' then
+			HV <= HV_VCNT_EXT(7 downto 1) & HV8 & HV_HCNT(8 downto 1);
+			EXINT_PENDING_SET <= '1';
+		end if;
+
+		if M3 ='0' then	
+			HV <= HV_VCNT_EXT(7 downto 1) & HV8 & HV_HCNT(8 downto 1);
+		end if;
 
 		-- H40 slow slots: 8aaaaaaa99aaaaaaa8aaaaaaa99aaaaaaa
 		-- 8, 10, 10, 10, 10, 10, 10, 10, 9, 9, 10, 10, 10, 10, 10, 10, 10, 8, 10, 10, 10, 10, 10, 10, 10, 9, 9, 10, 10, 10, 10, 10, 10, 10
@@ -3521,6 +3537,7 @@ end process;
 process( RST_N, CLK )
 begin
 	if RST_N = '0' then
+		EXINT_PENDING <= '0';
 		HINT_PENDING <= '0';
 		VINT_TG68_PENDING <= '0';
 	elsif rising_edge( CLK) then
@@ -3531,13 +3548,33 @@ begin
 				VINT_TG68_PENDING <= '0';
 			elsif HINT_FF = '1' then
 				HINT_PENDING <= '0';
+			elsif EXINT_FF = '1' then
+				EXINT_PENDING <= '0';
 			end if;
+		end if;
+		if EXINT_PENDING_SET = '1' then
+			EXINT_PENDING <= '1';
 		end if;
 		if HINT_PENDING_SET = '1' then
 			HINT_PENDING <= '1';
 		end if;
 		if VINT_TG68_PENDING_SET = '1' then
 			VINT_TG68_PENDING <= '1';
+		end if;
+	end if;	
+end process;
+
+-- EXINT
+EXINT <= EXINT_FF;
+process( RST_N, CLK )
+begin
+	if RST_N = '0' then
+		EXINT_FF <= '0';
+	elsif rising_edge( CLK) then
+		if EXINT_PENDING = '1' and IE2 = '1' then
+			EXINT_FF <= '1';
+		else
+			EXINT_FF <= '0';
 		end if;
 	end if;	
 end process;


### PR DESCRIPTION
Players can control a light gun with their mouse, gamepad, motion controller, etc.
All light gun games should be supported.
Adding external interrupt support with M3 and IE2 VDP registers. This is needed to support light guns.