### PR TITLE
Adding auto-region toggle for cartridge games.

### DIFF
--- a/MegaCD.sv
+++ b/MegaCD.sv
@@ -587,7 +587,7 @@ wire        gg_available2;
 
 MCD MCD
 (
-	.RST_N(~reset),
+	.RST_N(~(reset|rom_download)),
 	.CLK(clk_sys),
 	.ENABLE(1),
 	.MCD_RST_N(MCD_RST_N),

--- a/MegaCD.sv
+++ b/MegaCD.sv
@@ -189,6 +189,7 @@ localparam CONF_STR = {
 	"S0,CUE,Insert Disk;",
 	"-;",
 	"O67,Region,JP,US,EU;",
+	"oH,Auto Cart Region,Disabled,Header;",
 	"-;",
 	"C,Cheats;",
 	"H5OO,Cheats Enabled,Yes,No;",
@@ -1055,7 +1056,7 @@ always @(posedge clk_sys) begin
 	end
 
 	old_ready <= cart_hdr_ready;
-	if(~old_ready & cart_hdr_ready) begin
+	if(status[49] & ~old_ready & cart_hdr_ready) begin
 		region_set <= 1;
 		if(hdr_u) region_req <= 1;
 		else if(hdr_j) region_req <= 0;


### PR DESCRIPTION
Allows toggling region-specific content by disabling auto-region detection in Pier Solar/MSU-MD games and helps bypass bad header region designations.