### PR TITLE
Disable MUX restructuring to meet timing requirements

### DIFF
--- a/MegaCD.qsf
+++ b/MegaCD.qsf
@@ -37,7 +37,7 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_EFFORT EXTRA
 set_global_assignment -name PHYSICAL_SYNTHESIS_REGISTER_DUPLICATION ON
 set_global_assignment -name PHYSICAL_SYNTHESIS_REGISTER_RETIMING ON
 set_global_assignment -name OPTIMIZATION_TECHNIQUE SPEED
-set_global_assignment -name MUX_RESTRUCTURE ON
+set_global_assignment -name MUX_RESTRUCTURE OFF
 set_global_assignment -name REMOVE_REDUNDANT_LOGIC_CELLS ON
 set_global_assignment -name AUTO_DELAY_CHAINS_FOR_HIGH_FANOUT_INPUT_PINS ON
 set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC_FOR_AREA ON


### PR DESCRIPTION
Disabling the restructuring of MUX in the synthesis settings fixes the worst case setup slack being out of spec (was -0.400~ !):

![image](https://user-images.githubusercontent.com/16388068/168340764-9cc4c18e-656a-4740-b136-e22867c4dd7d.png)

But it comes at a significant cost in terms of logic space (from 60% to 73% usage):

![image](https://user-images.githubusercontent.com/16388068/168340790-63d1a294-7522-40ae-91c7-256772552527.png)

I did not notice a big difference in compilation time.

Submitting as draft PR since I'm not sure if this is the appropriate way to fix the timing. More of a workaround.