### PR TITLE
Update vdp.vhd - fix VDP counter reload on V30

### DIFF
--- a/rtl/GEN/vdp.vhd
+++ b/rtl/GEN/vdp.vhd
@@ -2379,7 +2379,8 @@ begin
 			end if;
 
 			if HV_HCNT = H_INT_POS then
-				if HV_VCNT = V_DISP_START + V_TOTAL_HEIGHT - 1 then --VDISP_START is negative
+				if HV_VCNT = V_DISP_START + V_TOTAL_HEIGHT - 1 and --VDISP_START is negative
+				        (V30 = '0' or PAL = '1') then -- NTSC with V30 will not reload the VCounter
 					--just after VSYNC
 					HV_VCNT <= V_DISP_START;
 				else


### PR DESCRIPTION
VDP: Vcounter doesn't reload with NTSC/V30 (SoR2 hacks will fail to load stage).

This fixes:
TMNT Shredder's RE-Revenge
Simpsons Sor2 hack 
Others potentially. 