### PR TITLE
T80: Preserve SP across warm-reset (#18 and #97)

### DIFF
--- a/rtl/GEN/T80/T80.vhd
+++ b/rtl/GEN/T80/T80.vhd
@@ -140,7 +140,8 @@ architecture rtl of T80 is
 	signal Ap, Fp               : std_logic_vector(7 downto 0);
 	signal I                    : std_logic_vector(7 downto 0);
 	signal R                    : unsigned(7 downto 0);
-	signal SP, PC               : unsigned(15 downto 0);
+	signal SP                   : unsigned(15 downto 0) := (others => '1');
+	signal PC                   : unsigned(15 downto 0);
 
 	signal RegDIH               : std_logic_vector(7 downto 0);
 	signal RegDIL               : std_logic_vector(7 downto 0);
@@ -389,7 +390,6 @@ begin
 			Fp <= (others => '1');
 			I <= (others => '0');
 			R <= (others => '0');
-			SP <= (others => '1');
 			Alternate <= '0';
 
 			Read_To_Reg_r <= "00000";


### PR DESCRIPTION
Real Z80 preserves SP on a warm reset. This fixes several missing sound effects in Dark Wizard, including the cursor sound, and fixes the missing gem pickup sound in Lords of Thunder.

In Dark Wizard's case at least, (and I assume in Lords of Thunder as well since it's also fixed by this change), it uploads a custom sound driver to the Z80 and performs a warm reset, which in T80's case resets SP to $FFFF instead of leaving it at the value the BIOS had previously set up. Z80 pushes the return address to the stack, which actually ends up in the banked 68k bus window (0xFFFD-0xFFFE) (and is subsequently a no-op). On ret, we read the return address from that same 0xFFFD address, grab whatever's there in BIOS ROM (the value $003C apparently), and drop the Z80 into the middle of its own delay-loop bytes and eventually into an endless spin.